### PR TITLE
Add globber for android api < VERSION_CODE.O

### DIFF
--- a/app/src/main/java/com/lvaccaro/lamp/Services/Globber.kt
+++ b/app/src/main/java/com/lvaccaro/lamp/Services/Globber.kt
@@ -1,0 +1,18 @@
+package com.lvaccaro.lamp.Services
+
+import java.io.*
+
+class Globber(val stream: InputStream, val file: File): Thread() {
+    override fun run() {
+        try {
+            val isr = InputStreamReader(stream)
+            val br = BufferedReader(isr)
+            while(!Thread.currentThread().isInterrupted()) {
+                val line = br.readLine()
+                file.appendText(line)
+            }
+        } catch (ioe: IOException) {
+            ioe.printStackTrace()
+        }
+    }
+}

--- a/app/src/main/java/com/lvaccaro/lamp/Services/LightningService.kt
+++ b/app/src/main/java/com/lvaccaro/lamp/Services/LightningService.kt
@@ -16,6 +16,7 @@ class LightningService : IntentService("LightningService") {
 
     val log = Logger.getLogger(LightningService::class.java.name)
     var process: Process? = null
+    var globber: Globber? = null
     val NOTIFICATION_ID = 573948
     val daemon = "lightningd"
 
@@ -117,6 +118,11 @@ class LightningService : IntentService("LightningService") {
             pb.redirectOutput(ProcessBuilder.Redirect.appendTo(logFile))
         }
         process = pb.start()
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
+            // Redirection output to file
+            globber = Globber(process!!.inputStream, logFile);
+            globber?.start()
+        }
         //return super.onStartCommand(intent, flags, startId)
         log.info("exit $daemon service")
 
@@ -158,7 +164,9 @@ class LightningService : IntentService("LightningService") {
         super.onDestroy()
         log.info("destroying core service")
         process?.destroy()
+        globber?.interrupt()
         process = null
+        globber = null
         cancelNotification()
     }
 }

--- a/app/src/main/java/com/lvaccaro/lamp/Services/TorService.kt
+++ b/app/src/main/java/com/lvaccaro/lamp/Services/TorService.kt
@@ -54,6 +54,8 @@ class TorService : IntentService("TorService") {
         pb.directory(binaryDir)
         pb.redirectErrorStream(true)
         val logFile = File(rootDir(), "$daemon.log")
+        logFile.delete()
+        logFile.createNewFile()
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             pb.redirectOutput(ProcessBuilder.Redirect.appendTo(logFile))
         }


### PR DESCRIPTION
Create a local file logger `Globber` for redirect process output/error is android api < VERSION_CODE.O . For more recent Android version, it could be used ProcessBuilder.redirectOutput() .

Close #2 