### PR TITLE
Append new line char in the log

### DIFF
--- a/app/src/main/java/com/lvaccaro/lamp/Services/Globber.kt
+++ b/app/src/main/java/com/lvaccaro/lamp/Services/Globber.kt
@@ -12,11 +12,11 @@ class Globber(val stream: InputStream, val file: File): Thread() {
             val isr = InputStreamReader(stream)
             val br = BufferedReader(isr)
             while(!Thread.currentThread().isInterrupted()) {
-                val line = br.readLine()
+                val line = br.readLine() + "\n"
                 file.appendText(line ?: "")
                 log.info(line)
             }
-        } catch (ioe: IOException) {
+        } catch (ioe: Exception) {
             ioe.printStackTrace()
         }
     }


### PR DESCRIPTION
Look the log doesn't include "\n" so the log file grow up in 1 line file. This cause reading errors and it doesn't show the logs itself.

Add a "\n" to fix the issue.
Note: booting procedure uses logs to check tor & lightning are up and running. So this fix could also improve the devil booting circus.

Bug reported in https://github.com/lvaccaro/lamp/issues/9