### PR TITLE
Add custom esplora endpoint in settings

### DIFF
--- a/app/src/main/java/com/lvaccaro/lamp/Services/LightningService.kt
+++ b/app/src/main/java/com/lvaccaro/lamp/Services/LightningService.kt
@@ -65,10 +65,11 @@ class LightningService : IntentService("LightningService") {
         if (sharedPref.getBoolean("enabled-esplora", true)) {
             val fileCert = File(getExternalFilesDir(Environment.DIRECTORY_DOWNLOADS)!!, "cacert.pem")
             // set esplora plugin
+            val endpoint = sharedPref.getString("esplora-api-endpoint", null) ?: "https://blockstream.info"
             options.addAll(arrayListOf<String>(
                 String.format("--disable-plugin=%s", "bcli"),
                 String.format("--esplora-cainfo=%s", fileCert.absolutePath),
-                String.format("--esplora-api-endpoint=https://blockstream.info/%s",
+                String.format("--esplora-api-endpoint=$endpoint/%s",
                     if ("testnet".equals(network)) "testnet/api" else "api")))
         } else {
             options.addAll(arrayListOf<String>(

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -55,4 +55,5 @@
     <string name="id_backup_and_restore"><![CDATA[Backup & restore]]></string>
     <string name="id_export_data">Export data</string>
     <string name="id_import_data">Import data</string>
+    <string name="id_esplora_api_endpoint">Esplora api endoint uri</string>
 </resources>

--- a/app/src/main/res/xml/root_preferences.xml
+++ b/app/src/main/res/xml/root_preferences.xml
@@ -72,6 +72,13 @@
             app:useSimpleSummaryProvider="true" />
 
         <EditTextPreference
+            app:key="esplora-api-endpoint"
+            app:title="@string/id_esplora_api_endpoint"
+            app:dependency="enabled-esplora"
+            app:defaultValue="https://blockstream.info"
+            app:useSimpleSummaryProvider="true" />
+
+        <EditTextPreference
             app:key="bitcoin-rpcuser"
             app:title="@string/id_bitcoind_rpc_username"
             app:useSimpleSummaryProvider="true" />


### PR DESCRIPTION
Add in settings a preference to set manually the esplora endpoint like the following "https://blockstream.info" as requested in #9 