### PR TITLE
Show general status text bar and block syncing progress

### DIFF
--- a/app/src/main/java/com/lvaccaro/lamp/MainActivity.kt
+++ b/app/src/main/java/com/lvaccaro/lamp/MainActivity.kt
@@ -150,6 +150,8 @@ class MainActivity : AppCompatActivity() {
                 "Offline. Rub the lamp to start."
             return
         }
+        doAsync { getInfo() }
+    }
 
     override fun onPause() {
         super.onPause()
@@ -273,7 +275,6 @@ class MainActivity : AppCompatActivity() {
             // turn off
             doAsync {
                 stop()
-                runOnUiThread { powerOff() }
             }
             return
         }
@@ -312,15 +313,17 @@ class MainActivity : AppCompatActivity() {
     }
 
     fun powerOff() {
+        if (powerImageView.isOn())
+            recreate()
         powerImageView.off()
-        recreate()
         timer?.cancel()
         findViewById<TextView>(R.id.statusText).text = "Offline. Rub the lamp to turn on."
     }
 
     fun powerOn() {
+        if (!powerImageView.isOn())
+            recreate()
         powerImageView.on()
-        recreate()
         findViewById<TextView>(R.id.statusText).text = ""
     }
 
@@ -572,8 +575,9 @@ class MainActivity : AppCompatActivity() {
                         "Lightning start failed",
                         Snackbar.LENGTH_LONG
                     ).show()
-                    powerImageView.off()
+                    Log.d(TAG, "******** Lightning run failed ********")
                     stopLightningService()
+                    powerOff()
                 }
                 return@doAsync
             }
@@ -589,7 +593,6 @@ class MainActivity : AppCompatActivity() {
                         e.localizedMessage,
                         Snackbar.LENGTH_LONG
                     ).show()
-                    powerImageView.off()
                 }
             }
         }
@@ -634,8 +637,11 @@ class MainActivity : AppCompatActivity() {
             log.info(e.localizedMessage)
             e.printStackTrace()
         }
-        stopLightningService()
-        stopTorService()
+        runOnUiThread {
+            stopLightningService()
+            stopTorService()
+            powerOff()
+        }
     }
 
     fun scanned(text: String) {

--- a/app/src/main/java/com/lvaccaro/lamp/MainActivity.kt
+++ b/app/src/main/java/com/lvaccaro/lamp/MainActivity.kt
@@ -288,11 +288,8 @@ class MainActivity : AppCompatActivity() {
         val tarFile = File(dir(), tarFilename())
         if (tarFile.exists()) {
             // Uncompress package
-            Snackbar.make(
-                findViewById(android.R.id.content),
-                "Package already downloaded. Uncompressing...",
-                Snackbar.LENGTH_LONG
-            ).show()
+            findViewById<TextView>(R.id.statusText).text =
+                "Package already downloaded. Uncompressing..."
             powerImageView.animating()
             doAsync {
                 uncompress(tarFile, rootDir())
@@ -301,12 +298,8 @@ class MainActivity : AppCompatActivity() {
                 }
             }
         } else {
-            Snackbar.make(
-                findViewById(android.R.id.content),
-                "Downloading...",
-                Snackbar.LENGTH_LONG
-            )
-                .show()
+            findViewById<TextView>(R.id.statusText).text =
+                "Downloading..."
             powerImageView.animating()
             download()
         }
@@ -410,11 +403,8 @@ class MainActivity : AppCompatActivity() {
                 return
 
             runOnUiThread {
-                Snackbar.make(
-                    findViewById(android.R.id.content),
-                    "Download Completed. Uncompressing...",
-                    Snackbar.LENGTH_LONG
-                ).show()
+                findViewById<TextView>(R.id.statusText).text =
+                    "Download Completed. Uncompressing..."
             }
             val tarFile = File(dir(), tarFilename())
             doAsync {

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -13,13 +13,6 @@
         android:layout_height="match_parent"
         android:orientation="vertical">
 
-        <com.lvaccaro.lamp.PowerImageView
-            android:id="@+id/powerImageView"
-            android:layout_width="200dp"
-            android:layout_height="200dp"
-            android:layout_gravity="center_horizontal"
-            android:background="@drawable/ic_lamp_off" />
-
         <TextView
             android:id="@+id/statusText"
             android:layout_width="match_parent"
@@ -27,6 +20,13 @@
             android:layout_marginStart="16dp"
             android:layout_marginEnd="16dp"
             android:textAlignment="center" />
+
+        <com.lvaccaro.lamp.PowerImageView
+            android:id="@+id/powerImageView"
+            android:layout_width="200dp"
+            android:layout_height="200dp"
+            android:layout_gravity="center_horizontal"
+            android:background="@drawable/ic_lamp_off" />
 
         <View
             android:layout_width="match_parent"


### PR DESCRIPTION
The idea is to show a progressbar until the chain is not synced under the title bar. Design/Funcional feedbacks are welcome.

On `getinfo`, it checks the `warning_lightningd_sync` field: if it exists, it shows a progressbar and it schedules a new `getinfo` command after 10s. That timer is cancelled on next `getInfo` or at activity `onPause()`.

Close https://github.com/lvaccaro/lamp/issues/18