### PR TITLE
Refactoring Parsing uri

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -74,6 +74,18 @@
 
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <data android:scheme="bitcoin" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+            </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <data android:scheme="lightning" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+            </intent-filter>
         </activity>
 
         <service

--- a/app/src/main/java/com/lvaccaro/lamp/MainActivity.kt
+++ b/app/src/main/java/com/lvaccaro/lamp/MainActivity.kt
@@ -133,6 +133,13 @@ class MainActivity : UriResultActivity() {
                 )
             }
         }
+
+        if (Intent.ACTION_VIEW == intent.action) {
+            if (arrayListOf<String>("bitcoin", "lightning").contains(intent.data.scheme)) {
+                val text = intent.data.toString().split(":").last()
+                parse(text)
+            }
+        }
     }
 
     override fun onResume() {

--- a/app/src/main/java/com/lvaccaro/lamp/UriResultActivity.kt
+++ b/app/src/main/java/com/lvaccaro/lamp/UriResultActivity.kt
@@ -1,0 +1,87 @@
+package com.lvaccaro.lamp
+
+import android.os.Bundle
+import android.util.Log
+import android.widget.Toast
+import androidx.appcompat.app.AlertDialog
+import androidx.appcompat.app.AppCompatActivity
+import com.lvaccaro.lamp.Channels.FundChannelFragment
+import java.lang.Exception
+
+open class UriResultActivity() : AppCompatActivity() {
+
+    val cli = LightningCli()
+    val TAG = "UriResultActivity"
+
+    fun parse(text: String) {
+        try {
+            val res = cli.exec(this, arrayOf("decodepay", text), true).toText()
+            runOnUiThread { showDecodePay(text, res) }
+            return;
+        } catch (e: Exception) {
+            Log.d(TAG, "decodepay: ${e.localizedMessage}")
+        }
+
+        try {
+            val res = cli.exec(this, arrayOf("connect", text), true).toJSONObject()
+            runOnUiThread { showConnect(res["id"] as String) }
+            return;
+        } catch (e: Exception) {
+            Log.d(TAG, "connect: ${e.localizedMessage}")
+        }
+
+        runOnUiThread {
+            Toast.makeText(
+                this,
+                "No action found",
+                Toast.LENGTH_LONG
+            ).show()
+        }
+    }
+
+    private fun showDecodePay(bolt11: String, decoded: String) {
+        AlertDialog.Builder(this)
+            .setTitle("decodepay")
+            .setMessage(decoded.toString())
+            .setCancelable(true)
+            .setPositiveButton("pay") { _, _ ->
+                // Pay invoice
+                try {
+                    cli.exec(this, arrayOf("pay", bolt11), true)
+                        .toJSONObject()
+                    runOnUiThread {
+                        Toast.makeText(
+                            this,
+                            "Invoice paid",
+                            Toast.LENGTH_LONG
+                        ).show()
+                    }
+                } catch (e: Exception) {
+                    runOnUiThread {
+                        AlertDialog.Builder(this)
+                            .setTitle("Error")
+                            .setMessage(e.localizedMessage)
+                            .show()
+                    }
+                }
+            }
+            .setNegativeButton("cancel") { _, _ -> }
+            .show()
+    }
+
+    private fun showConnect(id: String) {
+        AlertDialog.Builder(this)
+            .setTitle("connect")
+            .setMessage(id)
+            .setPositiveButton("fund channel") { _, _ ->
+                // Open fund channel fragment
+                val bottomSheetDialog = FundChannelFragment()
+                val args = Bundle()
+                args.putString("uri", id)
+                bottomSheetDialog.arguments = args
+                bottomSheetDialog.show(supportFragmentManager, "Fund channel")
+            }
+            .setNegativeButton("cancel") { _, _ -> }
+            .show()
+    }
+}

--- a/app/src/main/java/com/lvaccaro/lamp/UriResultActivity.kt
+++ b/app/src/main/java/com/lvaccaro/lamp/UriResultActivity.kt
@@ -32,12 +32,14 @@ open class UriResultActivity() : AppCompatActivity() {
         }
 
         try {
-            cli.exec(this, arrayOf("withdraw", text), true).toJSONObject()
-            // withdraw fails due by missing satoshi field
+            // pre-parsing text to avoid multi strings text
+            val address = text.split(" ").first()
+            cli.exec(this, arrayOf("withdraw", address), true).toJSONObject()
             return;
         } catch (e: Exception) {
             val res = JSONObject(e.localizedMessage)
             val message = res["message"] as String
+            // withdraw fails due by missing satoshi field
             if (message == "missing required parameter: satoshi") {
                 runOnUiThread { showWithdraw(text) }
                 return

--- a/app/src/main/java/com/lvaccaro/lamp/WithdrawFragment.kt
+++ b/app/src/main/java/com/lvaccaro/lamp/WithdrawFragment.kt
@@ -26,6 +26,8 @@ class WithdrawFragment: BottomSheetDialogFragment() {
         savedInstanceState: Bundle?
     ): View? {
         val view = inflater.inflate(R.layout.fragment_withdraw, container, false)
+        val address = arguments?.getString("address")
+        view.findViewById<TextView>(R.id.addressText).text = address ?: ""
         view.findViewById<Button>(R.id.confirmButton).setOnClickListener {
             val satoshi = view.findViewById<TextView>(R.id.satoshiText).text.toString()
             val address = view.findViewById<TextView>(R.id.addressText).text.toString()

--- a/app/src/main/res/layout/fragment_withdraw.xml
+++ b/app/src/main/res/layout/fragment_withdraw.xml
@@ -6,7 +6,7 @@
     <TextView
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:text="@string/id_invoice"
+        android:text="@string/id_withdraw"
         android:textStyle="bold"
         android:padding="8dp" />
 


### PR DESCRIPTION
-  Migrate uri parsing function and following actions from MainActivity to UriResultActivity; MainActivity is shorter then before and UriResultActivity could be reused.
- Add `withdraw` command at uri parsing following https://github.com/lvaccaro/lamp/issues/20 feedbacks.
- Pre-parsing uri text to avoid multi strings for withdraw command: avoid to pass a string like `<address> <satoshi>` to withdraw, because it send funds without any advise to the user.
- Support to open app with bitcoin scheme:
```
adb shell am start -a "android.intent.action.VIEW" -d "bitcoin:<address>"
```
- Support to open app with lightning scheme:
```
adb shell am start -a "android.intent.action.VIEW" -d "lightning:<bolt11>"
```
Note: this command could fail if daemon is off.