### PR TITLE
Allowing soft delete cert and archive file on clearbinary

### DIFF
--- a/app/src/main/java/com/lvaccaro/lamp/SettingsActivity.kt
+++ b/app/src/main/java/com/lvaccaro/lamp/SettingsActivity.kt
@@ -68,9 +68,9 @@ class SettingsActivity : AppCompatActivity() {
                     val dir = File(activity?.rootDir(), "")
                     val downloadDir =
                         activity?.getExternalFilesDir(Environment.DIRECTORY_DOWNLOADS)!!
-                    var resultOperation = File(downloadDir, MainActivity.tarFilename()).delete() &&
-                    File(downloadDir, "cacert.pem").delete() &&
-                    File(dir, "lightningd").delete() &&
+                    File(downloadDir, MainActivity.tarFilename()).delete()
+                    File(downloadDir, "cacert.pem").delete()
+                    val resultOperation = File(dir, "lightningd").delete() &&
                     File(dir, "lightning-cli").delete() &&
                     File(dir, "lightning_channeld").delete() &&
                     File(dir, "lightning_closingd").delete() &&


### PR DESCRIPTION
Now, `clearbinary` procedure could fail because `cacert.pem` and lightning archive not exists.
- `cacert.pem`: could not be downloaded
- lightning archive: could be just removed after downloaded

The clear procedure should continue also in the upper condition.