### PR TITLE
Update lightning_ndk to release_clightning_0.9.0

### DIFF
--- a/app/src/main/java/com/lvaccaro/lamp/MainActivity.kt
+++ b/app/src/main/java/com/lvaccaro/lamp/MainActivity.kt
@@ -52,7 +52,7 @@ class MainActivity : UriResultActivity() {
     var timer: Timer? = null
 
     companion object {
-        val RELEASE = "release_clightning_0.8.2"
+        val RELEASE = "release_clightning_0.9.0"
 
         fun arch(): String {
             var abi: String?


### PR DESCRIPTION
Update lightning_ndk to [release_clightning_0.9.0](https://github.com/lvaccaro/lightning_ndk/releases/tag/release_clightning_0.9.0) with clightning v0.9.0 and esplora plugin

Close #33 