### PR TITLE
Check nullable string before writing log

### DIFF
--- a/app/src/main/java/com/lvaccaro/lamp/services/Globber.kt
+++ b/app/src/main/java/com/lvaccaro/lamp/services/Globber.kt
@@ -11,9 +11,11 @@ class Globber(val stream: InputStream, val file: File): Thread() {
             val isr = InputStreamReader(stream)
             val br = BufferedReader(isr)
             while(!Thread.currentThread().isInterrupted()) {
-                val line = br.readLine() + "\n"
-                file.appendText(line ?: "")
-                log.info(line)
+                val line = br.readLine()
+                if (line != null && line.length > 0) {
+                    file.appendText("${line}\n")
+                    log.info(line)
+                }
             }
         } catch (ioe: Exception) {
             ioe.printStackTrace()


### PR DESCRIPTION
When clightning crash, `readLine()`returns a `null` value, that it was written in the log file. This MR checks nullable string before print and write the log in Globber class.