### PR TITLE
Add documentation about building from cmdline

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,10 @@ On Lamp settings, enable proxy using orbot localhost gateway:
 
 Read the following instructions at [Tor on clightning](https://lightning.readthedocs.io/TOR.html) to setup address on different network scenario.
 
+## Building
+
+ * [in Linux using cmdline tools](doc/cmdline-tools-setup.md)
+
 ## References
 
 - [ABCore](https://github.com/greenaddress/abcore) Android Bitcoin Core wallet

--- a/doc/cmdline-tools-setup.md
+++ b/doc/cmdline-tools-setup.md
@@ -1,0 +1,32 @@
+# How to setup cmdline-tools to build and test this project in Ubuntu
+
+Download https://developer.android.com/studio/#command-tools
+
+Run following commands:
+
+```
+## to get rid of openjdk11 and replace it with 8
+## run following commented lines as root
+# apt-get autoremove openjdk*
+# apt-get install openjdk-8-jdk
+cd $HOME
+mkdir -p android_sdk/cmdline-tools
+cd android_sdk/cmdline-tools
+unzip ~/commandlinetools-linux-6609375_latest.zip
+export ANDROID_SDK_ROOT=$HOME/android_sdk ###
+tools/bin/sdkmanager --install "cmdline-tools;latest"
+tools/bin/sdkmanager --install "build-tools;29.0.3"
+tools/bin/sdkmanager --install "platforms;android-28"
+rm -rf tools
+export PATH=$HOME/android_sdk/cmdline-tools/latest/bin:$OLDPATH ###
+yes | sdkmanager --licenses
+cd ~/src/lamp
+./gradlew tasks
+./gradlew build
+# connect your phone/emulator (check: adb devices, adb shell)
+./gradlew installDebug
+```
+
+Consider adding lines marked with `###` to your `~/.profile` or equivalent.
+
+See https://stackoverflow.com/questions/60440509/android-command-line-tools-sdkmanager-always-shows-warning-could-not-create-se


### PR DESCRIPTION
This quick guide may be inspirational also to users
of other supported architectures (Windows, Mac),
but it focuses on Linux, particularly Ubuntu (with its
magic to make JDK work).