### PR TITLE
Crash with v0.9.1 fixed and fixed  also the request error at startup

### DIFF
--- a/app/src/main/java/com/lvaccaro/lamp/services/LightningService.kt
+++ b/app/src/main/java/com/lvaccaro/lamp/services/LightningService.kt
@@ -50,16 +50,18 @@ class LightningService : IntentService("LightningService") {
         var proxy = sharedPref.getString("proxy", "").toString()
         var announceaddr = sharedPref.getString("announce-addr", "").toString()
         var bindaddr = sharedPref.getString("bind-addr", "").toString()
-        var addr = sharedPref.getString("addr", "").toString()
+        val addr = sharedPref.getString("addr", "").toString()
         val alias = sharedPref.getString("alias", "").toString()
         val ignoreFeeLimits = sharedPref.getBoolean("ignore-fee-limits", false)
+        val torEnabled = sharedPref.getBoolean("enabled-tor", true)
+        val proxyEnabled = sharedPref.getBoolean("proxy-enabled", false)
 
         var options = arrayListOf<String>(
             String.format("%s/lightningd/%s", binaryDir.canonicalPath, daemon),
             String.format("--network=%s", network),
             String.format("--log-level=%s", logLevel),
             String.format("--lightning-dir=%s", lightningDir.path),
-            String.format("--plugin-dir=%s", File(binaryDir.path , "plugins").path),
+            //String.format("--plugin-dir=%s", File(binaryDir.path , "plugins").path),
             String.format("--ignore-fee-limits=%b", ignoreFeeLimits),
             // 10 days to catch a cheating attempt
             String.format("--watchtime-blocks=%s", 10 * 24 * 6))
@@ -89,7 +91,7 @@ class LightningService : IntentService("LightningService") {
                 String.format("--bitcoin-rpcpassword=%s", rpcpassword)))
         }
 
-        if (sharedPref.getBoolean("enabled-tor", true)) {
+        if (torEnabled) {
             // setup Tor
             proxy = "127.0.0.1:9050"
             bindaddr = "127.0.0.1:9735"
@@ -100,7 +102,7 @@ class LightningService : IntentService("LightningService") {
             options.add("--always-use-proxy=true")
         }
 
-        if (proxy.isNotEmpty()) {
+        if (proxy.isNotEmpty() && (torEnabled || proxyEnabled)) {
             options.add(String.format("--proxy=%s", proxy))
             options.add("--always-use-proxy=true")
         }

--- a/app/src/main/res/xml/root_preferences.xml
+++ b/app/src/main/res/xml/root_preferences.xml
@@ -17,7 +17,7 @@
             app:useSimpleSummaryProvider="true" />
 
         <ListPreference
-            app:defaultValue="io"
+            app:defaultValue="debug"
             app:entries="@array/loglevels"
             app:entryValues="@array/loglevels"
             app:key="log-level"


### PR DESCRIPTION
After a couple of hours to debug, I can see that the new version of ndk works fine (like magic), but the LightningService need refactoring.

Basically, there are two "bug" inside the actual master, that there are described below:

- Lightnind root dir (by default .lightningd) has the same structure that lightnind aspect, this makes the propriety `--plugind-dir` not necessary, I think that lightnind is not able to find the duplicate dir for plugin, but this is another story. I added a comment inside the code to explain it.
- Inside the share preferences there are set already the address of the proxy, and this force the config to set the proxy to the command line, at the moment esplora plugin is able to configure proxy without any help for the user and this brings esplora to believe that there is some proxy, but is not true, and it is not able to perform the request because the proxy does not exist inside the system.

I hope this can help!

Signed-off-by: Vincenzo Palazzo <vincenzopalazzodev@gmail.com>