### PR TITLE
Check and update ligthning_ndk based on stored release tag name

### DIFF
--- a/app/src/main/java/com/lvaccaro/lamp/MainActivity.kt
+++ b/app/src/main/java/com/lvaccaro/lamp/MainActivity.kt
@@ -143,6 +143,8 @@ class MainActivity : UriResultActivity() {
                 .setMessage("New lightning_ndk version is available: ${Archive.RELEASE}. Make a backup from Settings. Tap Update to start download.")
                 .setPositiveButton(android.R.string.cancel) { _, _ -> }
                 .setPositiveButton(R.string.id_update) { _, _ ->
+                    // Stop node
+                    stop()
                     // Delete previous binaries
                     val dir = File(rootDir(), "")
                     val downloadDir = getExternalFilesDir(Environment.DIRECTORY_DOWNLOADS)!!

--- a/app/src/main/java/com/lvaccaro/lamp/activities/SettingsActivity.kt
+++ b/app/src/main/java/com/lvaccaro/lamp/activities/SettingsActivity.kt
@@ -1,5 +1,6 @@
 package com.lvaccaro.lamp.activities
 
+import android.content.Context
 import android.content.Intent
 import android.net.Uri
 import android.os.Bundle
@@ -11,6 +12,7 @@ import androidx.preference.PreferenceFragmentCompat
 import com.lvaccaro.lamp.MainActivity
 import com.lvaccaro.lamp.R
 import com.lvaccaro.lamp.rootDir
+import com.lvaccaro.lamp.utils.Archive
 import org.apache.commons.compress.utils.IOUtils
 import org.jetbrains.anko.doAsync
 import java.io.*
@@ -80,16 +82,10 @@ class SettingsActivity : AppCompatActivity() {
                     val dir = File(activity?.rootDir(), "")
                     val downloadDir =
                         activity?.getExternalFilesDir(Environment.DIRECTORY_DOWNLOADS)!!
-                    File(downloadDir,
-                        MainActivity.tarFilename()
-                    ).delete()
+                    Archive.delete(downloadDir)
                     File(downloadDir, "cacert.pem").delete()
-                    val resultOperation = File(dir, "cli").deleteRecursively() &&
-                    File(dir, "lightningd").deleteRecursively() &&
-                    File(dir, "plugins").deleteRecursively() &&
-                    File(dir, "bitcoin-cli").delete() &&
-                    File(dir, "bitcoind").delete() &&
-                    File(dir, "tor").delete()
+                    val resultOperation = Archive.deleteUncompressed(dir)
+                    activity?.let { it.getPreferences(Context.MODE_PRIVATE).edit().remove("RELEASE").apply() }
 
                     if(resultOperation){
                         showToast(

--- a/app/src/main/java/com/lvaccaro/lamp/utils/Archive.kt
+++ b/app/src/main/java/com/lvaccaro/lamp/utils/Archive.kt
@@ -1,6 +1,6 @@
 package com.lvaccaro.lamp.utils
 
-import android.util.Log
+import android.os.Build
 import org.apache.commons.compress.archivers.tar.TarArchiveEntry
 import org.apache.commons.compress.archivers.tar.TarArchiveInputStream
 import org.apache.commons.compress.compressors.xz.XZCompressorInputStream
@@ -12,46 +12,90 @@ import java.io.FileOutputStream
 
 class Archive {
 
-    fun uncompressXZ(inputFile: File, outputDir: File) {
-        mkdir(outputDir)
-        mkdir(File(outputDir, "plugins"))
-        mkdir(File(outputDir, "lightningd"))
-        mkdir(File(outputDir, "cli"))
+    companion object {
+        val RELEASE = "release_clightning_0.9.1"
 
-        val input = TarArchiveInputStream(
-            BufferedInputStream(
-                XZCompressorInputStream(
-                    BufferedInputStream(FileInputStream(inputFile))
+        fun arch(): String {
+            var abi: String?
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+                abi = Build.SUPPORTED_ABIS[0]
+            } else {
+                abi = Build.CPU_ABI
+            }
+            when (abi) {
+                "armeabi-v7a" -> return "arm-linux-androideabi"
+                "arm64-v8a" -> return "aarch64-linux-android"
+                "x86" -> return "i686-linux-android"
+                "x86_64" -> return "x86_64-linux-android"
+            }
+            throw Error("No arch found")
+        }
+
+        fun tarFilename(): String {
+            val ARCH = arch()
+            val PACKAGE = "bitcoin"
+            return "${ARCH}_${PACKAGE}.tar.xz"
+        }
+
+        fun url(): String {
+            val TAR_FILENAME = tarFilename()
+            return "https://github.com/lvaccaro/lightning_ndk/releases/download/${RELEASE}/${TAR_FILENAME}"
+        }
+
+        fun delete(downloadDir: File): Boolean {
+            return File(downloadDir, tarFilename()).delete()
+        }
+
+        fun deleteUncompressed(dir: File): Boolean {
+            return File(dir, "cli").deleteRecursively() &&
+                    File(dir, "lightningd").deleteRecursively() &&
+                    File(dir, "plugins").deleteRecursively() &&
+                    File(dir, "bitcoin-cli").delete() &&
+                    File(dir, "bitcoind").delete() &&
+                    File(dir, "tor").delete()
+        }
+
+        fun uncompressXZ(inputFile: File, outputDir: File) {
+            mkdir(outputDir)
+            mkdir(File(outputDir, "plugins"))
+            mkdir(File(outputDir, "lightningd"))
+            mkdir(File(outputDir, "cli"))
+
+            val input = TarArchiveInputStream(
+                BufferedInputStream(
+                    XZCompressorInputStream(
+                        BufferedInputStream(FileInputStream(inputFile))
+                    )
                 )
             )
-        )
-        var counter = 0
-        var entry = input.nextEntry
-        while (entry != null) {
+            var counter = 0
+            var entry = input.nextEntry
+            while (entry != null) {
 
-            val name = entry.name
-            val f = File(outputDir, name)
+                val name = entry.name
+                val f = File(outputDir, name)
 
-            var out = FileOutputStream(f)
-            try {
-                IOUtils.copy(input, out)
-            } finally {
-                IOUtils.closeQuietly(out)
+                var out = FileOutputStream(f)
+                try {
+                    IOUtils.copy(input, out)
+                } finally {
+                    IOUtils.closeQuietly(out)
+                }
+
+                val mode = (entry as TarArchiveEntry).mode
+                //noinspection ResultOfMethodCallIgnored
+                f.setExecutable(true, mode and 1 == 0)
+                entry = input.nextEntry
+                counter++
             }
-
-            val mode = (entry as TarArchiveEntry).mode
-            //noinspection ResultOfMethodCallIgnored
-            f.setExecutable(true, mode and 1 == 0)
-            entry = input.nextEntry
-            counter++
+            IOUtils.closeQuietly(input)
+            inputFile.delete()
         }
-        IOUtils.closeQuietly(input)
-        inputFile.delete()
-    }
 
-    fun mkdir(dir: File) {
-        if (!dir.exists()) {
-            dir.mkdir()
+        fun mkdir(dir: File) {
+            if (!dir.exists()) {
+                dir.mkdir()
+            }
         }
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -64,5 +64,6 @@
     <string name="id_autostart">Autostart</string>
     <string name="id_lamp_settings">Lamp settings</string>
     <string name="id_run_lightning_on_Lamp_startup">Run lightning on Lamp startup</string>
+    <string name="id_update">Update</string>
 
 </resources>


### PR DESCRIPTION
Partial proposal for #27 .

On main activity start, the app compares lightning_ndk hardcoded version `Archive.RELEASE` with stored `RELEASE` preferences, if not equals, it opens an update alert dialog. The updating procedure deletes the previous binaries and start downloading.

Some others code improvements:
- move archive information from `MainActivity.kt` to `Archive.kt` for better reuse.
- using relative path for plugins dir to avoid double plugin registrations