### PR TITLE
Fixed navigation method for main activity into manifest and fixed waitning time startup node

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -77,7 +77,8 @@
                 android:name="android.support.PARENT_ACTIVITY"
                 android:value="com.lvaccaro.lamp.MainActivity" />
         </activity>
-        <activity android:name=".MainActivity">
+        <activity android:name=".MainActivity"
+            android:launchMode="singleTop">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/app/src/main/java/com/lvaccaro/lamp/MainActivity.kt
+++ b/app/src/main/java/com/lvaccaro/lamp/MainActivity.kt
@@ -280,14 +280,16 @@ class MainActivity : UriResultActivity() {
         val peers: JSONArray = listPeers["peers"] as JSONArray
 
         balanceText.text = "${(SimulatorPlugin.funds(listPeers).toDouble()/1000)} sat"
+        runOnUiThread {
+            recyclerView.adapter = BalanceAdapter(
+                arrayListOf(
+                    Balance("Spendable in channels", "${peers.length()} Peers", "${SimulatorPlugin.funds(listPeers).toDouble()/1000} sat"),
+                    Balance("Locked in channels", "${channels.length()} Channels", "${SimulatorPlugin.offchain(listFunds).toDouble()/1000} sat"),
+                    Balance("Bitcoin on chain", "${outputs.length()} Transactions", "${SimulatorPlugin.onchain(listFunds)} sat")
+                ), null
+            )
+        }
 
-        recyclerView.adapter = BalanceAdapter(
-            arrayListOf(
-                Balance("Spendable in channels", "${peers.length()} Peers", "${SimulatorPlugin.funds(listPeers).toDouble()/1000} sat"),
-                Balance("Locked in channels", "${channels.length()} Channels", "${SimulatorPlugin.offchain(listFunds).toDouble()/1000} sat"),
-                Balance("Bitcoin on chain", "${outputs.length()} Transactions", "${SimulatorPlugin.onchain(listFunds)} sat")
-            ), null
-        )
     }
 
     private fun isServiceRunning(name: String): Boolean {
@@ -654,8 +656,8 @@ class MainActivity : UriResultActivity() {
                     powerOff()
                     stopTorService()
                 }
-                NewTransaction.NOTIFICATION, NewChannelPayment.NOTIFICATION, PaidInvoice.NOTIFICATION -> runOnUiThread {
-                    doAsync { updateBalanceView(context) }
+                NewTransaction.NOTIFICATION, NewChannelPayment.NOTIFICATION, PaidInvoice.NOTIFICATION -> doAsync {
+                    updateBalanceView(context)
                 }
                 NodeUpHandler.NOTIFICATION  -> {
                     isRunning = true

--- a/app/src/main/java/com/lvaccaro/lamp/handlers/NodeUpHandler.kt
+++ b/app/src/main/java/com/lvaccaro/lamp/handlers/NodeUpHandler.kt
@@ -1,0 +1,29 @@
+package com.lvaccaro.lamp.handlers
+
+import android.content.Context
+import android.content.Intent
+import android.util.Log
+import androidx.localbroadcastmanager.content.LocalBroadcastManager
+
+/**
+ * @author https://github.com/vincenzopalazzo
+ */
+class NodeUpHandler: IEventHandler{
+
+    companion object {
+        val TAG = NodeUpHandler::class.java.canonicalName
+        val NOTIFICATION: String = "NODE_UP_NOTIFICATION"
+        val PATTERN_ONE = "lightningd: Server started with public key"
+    }
+
+    override fun doReceive(context: Context, information: String) {
+        if(information.contains(PATTERN_ONE)){
+            Log.d(TAG, "****** Action received ${NewChannelPayment.NOTIFICATION} ******")
+            val intent = Intent()
+            intent.action = NodeUpHandler.NOTIFICATION
+            intent.putExtra("message", "Node running")
+            LocalBroadcastManager.getInstance(context).sendBroadcast(intent)
+        }
+    }
+
+}

--- a/app/src/main/java/com/lvaccaro/lamp/utils/LogObserver.kt
+++ b/app/src/main/java/com/lvaccaro/lamp/utils/LogObserver.kt
@@ -36,6 +36,9 @@ import java.io.LineNumberReader
  * ---- Node crash
  * Pattern log: **BROKEN**
  *
+ * -- Node up
+ * Patter log: "lightningd: Server started with public key"
+ *
  *
  * @author https://github.com/vincenzopalazzo
  */
@@ -55,8 +58,8 @@ class LogObserver(val context: Context, val path: String, val nameFile: String) 
     private var lineNumberReader: LineNumberReader? = null
 
 
-    fun initHandler() {
-        actionHandler = ArrayList<IEventHandler>()
+    private fun initHandler() {
+        actionHandler = ArrayList()
         actionHandler.addAll(
             arrayOf(
                 NewChannelPayment(),
@@ -71,9 +74,9 @@ class LogObserver(val context: Context, val path: String, val nameFile: String) 
 
     override fun onEvent(event: Int, file: String?) {
         if(file == null) return
-        if (file?.equals(nameFile)) {
+        if (file == nameFile) {
             when (event) {
-                FileObserver.MODIFY -> readNewLines()
+                MODIFY -> readNewLines()
             }
         }
     }
@@ -94,7 +97,7 @@ class LogObserver(val context: Context, val path: String, val nameFile: String) 
     }
 
     private fun readLogLine(line: String) {
-        actionHandler.forEach { it -> it.doReceive(context, line) }
+        actionHandler.forEach { it.doReceive(context, line) }
         actualLine++
     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
         
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.0.1'
+        classpath 'com.android.tools.build:gradle:4.1.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sun Jul 26 16:47:21 CEST 2020
+#Sat Nov 28 23:56:37 CET 2020
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.1.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-bin.zip


### PR DESCRIPTION
This PR closes #69 (considered history for the actual master) and introduce the navigation change about MainActivity.

In addition, I increase the waiting time for a lightning startup because I noted that the lamp showdown the node during the node startup in some sense.

This is the log shared from the application, but maybe this is caused by esplora because the next call should be it. However, a little bit more time help to wait for the log from esplora

```
------- LOG lightningd.log CONTENT ----------
2020-10-27T10:26:16.175Z DEBUG   plugin-manager: blacklist for bcli
2020-10-27T10:26:16.178Z INFO    plugin-manager: /data/user/0/com.lvaccaro.lamp/no_backup/lightningd/../plugins/bcli: disabled via disable-plugin
2020-10-27T10:26:16.175Z DEBUG   plugin-manager: blacklist for bcli
2020-10-27T10:26:16.178Z INFO    plugin-manager: /data/user/0/com.lvaccaro.lamp/no_backup/lightningd/../plugins/bcli: disabled via disable-plugin
2020-10-27T10:26:16.182Z DEBUG   plugin-manager: started(30227) /data/user/0/com.lvaccaro.lamp/no_backup/lightningd/../plugins/autoclean
2020-10-27T10:26:16.185Z DEBUG   plugin-manager: started(30228) /data/user/0/com.lvaccaro.lamp/no_backup/lightningd/../plugins/keysend
2020-10-27T10:26:16.189Z DEBUG   plugin-manager: started(30229) /data/user/0/com.lvaccaro.lamp/no_backup/lightningd/../plugins/pay
2020-10-27T10:26:16.192Z DEBUG   plugin-manager: started(30230) /data/user/0/com.lvaccaro.lamp/no_backup/lightningd/../plugins/txprepare
2020-10-27T10:26:16.195Z DEBUG   plugin-manager: started(30231) /data/user/0/com.lvaccaro.lamp/no_backup/lightningd/../plugins/spenderp
2020-10-27T10:26:16.200Z DEBUG   plugin-manager: started(30232) /data/user/0/com.lvaccaro.lamp/no_backup/lightningd/../plugins/esplora
2020-10-27T10:26:16.229Z INFO    plugin-esplora: getutxout
2020-10-27T10:26:16.232Z DEBUG   lightningd: testing /data/user/0/com.lvaccaro.lamp/no_backup/lightningd/lightning_channeld
2020-10-27T10:26:16.239Z DEBUG   lightningd: testing /data/user/0/com.lvaccaro.lamp/no_backup/lightningd/lightning_closingd
2020-10-27T10:26:16.245Z DEBUG   lightningd: testing /data/user/0/com.lvaccaro.lamp/no_backup/lightningd/lightning_connectd
2020-10-27T10:26:16.252Z DEBUG   lightningd: testing /data/user/0/com.lvaccaro.lamp/no_backup/lightningd/lightning_gossipd
2020-10-27T10:26:16.259Z DEBUG   lightningd: testing /data/user/0/com.lvaccaro.lamp/no_backup/lightningd/lightning_hsmd
2020-10-27T10:26:16.265Z DEBUG   lightningd: testing /data/user/0/com.lvaccaro.lamp/no_backup/lightningd/lightning_onchaind
2020-10-27T10:26:16.273Z DEBUG   lightningd: testing /data/user/0/com.lvaccaro.lamp/no_backup/lightningd/lightning_openingd
2020-10-27T10:26:16.276Z DEBUG   hsmd: pid 30240, msgfd 25
2020-10-27T10:26:16.388Z DEBUG   connectd: pid 30241, msgfd 29
2020-10-27T10:26:16.388Z DEBUG   hsmd: Client: Received message 11 from client
2020-10-27T10:26:16.388Z DEBUG   hsmd: Client: Received message 9 from client
2020-10-27T10:26:16.389Z DEBUG   hsmd: new_client: 0
2020-10-27T10:26:16.404Z DEBUG   connectd: Proxy address: 127.0.0.1:9050
2020-10-27T10:26:16.404Z DEBUG   connectd: Created IPv6 listener on port 9735
2020-10-27T10:26:16.404Z DEBUG   connectd: Created IPv4 listener on port 9735
2020-10-27T10:26:16.404Z DEBUG   connectd: REPLY WIRE_CONNECTD_INIT_REPLY with 0 fds
2020-10-27T10:26:16.407Z DEBUG   gossipd: pid 30242, msgfd 28
2020-10-27T10:26:16.430Z DEBUG   hsmd: Client: Received message 9 from client
2020-10-27T10:26:16.430Z DEBUG   hsmd: new_client: 0
2020-10-27T10:26:16.431Z UNUSUAL plugin-esplora: lightnind require the proxy always,in this cases the esplora plugin should be use the proxy
2020-10-27T10:26:16.431Z INFO    plugin-esplora: ------------ esplora initialized ------------
2020-10-27T10:26:16.431Z INFO    plugin-esplora: esplora endpoint https://blockstream.info/api
2020-10-27T10:26:16.431Z INFO    plugin-esplora: proxy configuration 127.0.0.1:9050
2020-10-27T10:26:16.431Z DEBUG   lightningd: All Bitcoin plugin commands registered
2020-10-27T10:26:16.432Z **BROKEN** gossipd: gossip_store_compact: bad version
2020-10-27T10:26:16.433Z UNUSUAL gossipd: Gossip store version 0 not 8: removing
2020-10-27T10:26:16.433Z DEBUG   gossipd: total store load time: 0 msec
2020-10-27T10:26:16.433Z DEBUG   gossipd: gossip_store: Read 0/0/0/0 cannounce/cupdate/nannounce/cdelete from store (0 deleted) in 1 bytes
2020-10-27T10:26:16.433Z DEBUG   gossipd: seeker: state = STARTING_UP New seeker
2020-10-27T10:26:22.096Z INFO    plugin-esplora: getchaininfo
2020-10-27T10:26:22.096Z INFO    plugin-esplora: block_genesis: 000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f
2020-10-27T10:26:22.096Z INFO    plugin-esplora: blockcount: 654438
2020-10-27T10:26:22.425Z DEBUG   lightningd: Smoothed feerate estimate for opening initialized to polled estimate 4317
2020-10-27T10:26:22.425Z DEBUG   lightningd: Feerate estimate for opening set to 4317 (was 0)
2020-10-27T10:26:22.425Z DEBUG   lightningd: Smoothed feerate estimate for mutual_close initialized to polled estimate 4317
2020-10-27T10:26:22.425Z DEBUG   lightningd: Feerate estimate for mutual_close set to 4317 (was 0)
2020-10-27T10:26:22.425Z DEBUG   lightningd: Smoothed feerate estimate for unilateral_close initialized to polled estimate 4317
2020-10-27T10:26:22.425Z DEBUG   lightningd: Feerate estimate for unilateral_close set to 4317 (was 0)
2020-10-27T10:26:22.425Z DEBUG   lightningd: Smoothed feerate estimate for delayed_to_us initialized to polled estimate 4317
2020-10-27T10:26:22.425Z DEBUG   lightningd: Feerate estimate for delayed_to_us set to 4317 (was 0)
2020-10-27T10:26:22.425Z DEBUG   lightningd: Smoothed feerate estimate for htlc_resolution initialized to polled estimate 4317
2020-10-27T10:26:22.425Z DEBUG   lightningd: Feerate estimate for htlc_resolution set to 4317 (was 0)
2020-10-27T10:26:22.425Z DEBUG   lightningd: Smoothed feerate estimate for penalty initialized to polled estimate 4317
2020-10-27T10:26:22.425Z DEBUG   lightningd: Feerate estimate for penalty set to 4317 (was 0)
2020-10-27T10:26:22.425Z DEBUG   lightningd: Smoothed feerate estimate for min_acceptable initialized to polled estimate 1384
2020-10-27T10:26:22.425Z DEBUG   lightningd: Feerate estimate for min_acceptable set to 1384 (was 0)
2020-10-27T10:26:22.425Z DEBUG   lightningd: Smoothed feerate estimate for max_acceptable initialized to polled estimate 43170
2020-10-27T10:26:22.425Z DEBUG   lightningd: Feerate estimate for max_acceptable set to 43170 (was 0)
```